### PR TITLE
Installer imrpovements

### DIFF
--- a/mpex.py
+++ b/mpex.py
@@ -68,7 +68,7 @@ class MPEx:
         res = raw_input(msg)
         return res == 'y'
 
-if __name__ == '__main__':
+def main():
     from getpass import getpass
     args = parse_args()
     if args.logfile in ('-' ,''):
@@ -95,3 +95,5 @@ if __name__ == '__main__':
         exit()
     print reply
 
+if __name__ == '__main__':
+  main()

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(name='pyMPEx',
       version='1.0',
@@ -32,4 +32,5 @@ setup(name='pyMPEx',
       author_email='support@azelphur.com',
       url='https://github.com/Azelphur/pyMPEx',
       py_modules=['mpex'],
-      requires=['gnupg'])
+      entry_points = {'console_scripts': ['mpex = mpex:main']},
+      install_requires=['python-gnupg'])


### PR DESCRIPTION
Thanks for starting this project.  I made some changes that improve install.

Migrated to setuptools and added entry point for executable mpex script. After 'setup.py install', user can run mpex.py by simply typing 'mpex'.

Also, fixed install requirement to use full gnupg package name - will automatically download python-gnupg during install.

Thanks,
-P
